### PR TITLE
feat: Add option to skip overwriting existing secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,4 @@ TARGET_REPO=target-repo
 # Logging and Behavior Flags
 # VERBOSE=true
 # SKIP_ENVS=true
+# SKIP_OVERWRITE=true

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ make help         # Show all available commands
 - `--target-pat`: Target PAT (required if GITHUB_TOKEN not set)
 - `--verbose`: Enable verbose logging (shows debug messages)
 - `--skip-envs`: Skip environment recreation (by default environments are recreated)
+- `--skip-overwrite`: Skip writing secrets that already exist in target
 - `--org-to-org`: Migrate only organization-level secrets (requires `--org-to-org` flag, ignores repo and env secrets)
 - `--source-endpoint`: GitHub API endpoint for source (default: `https://api.github.com`)
 - `--target-endpoint`: GitHub API endpoint for target (default: `https://api.github.com`)
@@ -465,6 +466,7 @@ All CLI flags can also be set via environment variables:
 **Options:**
 - `VERBOSE`: Enable verbose logging (set to any non-empty value)
 - `SKIP_ENVS`: Skip environment recreation (set to any non-empty value)
+- `SKIP_OVERWRITE`: Skip writing secrets that already exist in target (set to any non-empty value)
 - `ORG_TO_ORG`: Migrate only organization-level secrets (set to any non-empty value)
 
 ### Custom Endpoints (GHEC Data Residency, GHES, EMU)
@@ -750,6 +752,7 @@ Options:
   --target-endpoint TEXT    GitHub API endpoint for target (default: https://api.github.com)
   --verbose                 Enable verbose logging
   --skip-envs               Skip environment recreation
+  --skip-overwrite          Skip writing secrets that already exist in target
   --org-to-org              Migrate only organization-level secrets
   --help                    Show help message
 ```

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -58,6 +58,12 @@ from src.core.workflow_generator import normalize_endpoint
     help="Skip environment recreation (by default environments are recreated)"
 )
 @click.option(
+    "--skip-overwrite",
+    is_flag=True,
+    envvar="SKIP_OVERWRITE",
+    help="Skip writing secrets that already exist in the target"
+)
+@click.option(
     "--org-to-org",
     is_flag=True,
     envvar="ORG_TO_ORG",
@@ -84,6 +90,7 @@ def migrate(
     target_pat,
     verbose,
     skip_envs,
+    skip_overwrite,
     org_to_org,
     source_endpoint,
     target_endpoint,
@@ -180,6 +187,7 @@ def migrate(
             target_pat=target_pat_value,
             verbose=verbose,
             skip_envs=skip_envs,
+            skip_overwrite=skip_overwrite,
             org_to_org=org_to_org,
             source_endpoint=source_endpoint,
             target_endpoint=target_endpoint

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -14,6 +14,7 @@ class MigrationConfig:
         target_repo: str = "",
         verbose: bool = False,
         skip_envs: bool = False,
+        skip_overwrite: bool = False,
         org_to_org: bool = False,
         source_endpoint: str = "https://api.github.com",
         target_endpoint: str = "https://api.github.com"
@@ -26,6 +27,7 @@ class MigrationConfig:
         self.target_pat = target_pat
         self.verbose = verbose
         self.skip_envs = skip_envs
+        self.skip_overwrite = skip_overwrite
         self.org_to_org = org_to_org
         self.source_endpoint = source_endpoint
         self.target_endpoint = target_endpoint

--- a/src/core/migrator.py
+++ b/src/core/migrator.py
@@ -493,7 +493,8 @@ class Migrator:
                 org_secrets=list(secrets_to_migrate.keys()),
                 org_secrets_scope=org_secrets_scope_for_target,
                 source_endpoint=self.config.source_endpoint,
-                target_endpoint=self.config.target_endpoint
+                target_endpoint=self.config.target_endpoint,
+                skip_overwrite=self.config.skip_overwrite,
             )
             
             # Step 3: Create migration branch and push workflow
@@ -680,7 +681,8 @@ class Migrator:
             env_secrets=env_secrets_info,
             repo_secrets=secrets_to_migrate,
             source_endpoint=self.config.source_endpoint,
-            target_endpoint=self.config.target_endpoint
+            target_endpoint=self.config.target_endpoint,
+            skip_overwrite=self.config.skip_overwrite,
         )
         self.log.debug("Creating workflow file...")
         workflow_commit_sha = self.source_api.create_file(

--- a/src/core/workflow_generator.py
+++ b/src/core/workflow_generator.py
@@ -105,7 +105,15 @@ def sanitize_job_id(name: str) -> str:
     return sanitized
 
 
-def generate_environment_secret_steps(env_secrets: Dict[str, List[str]], source_org: str, source_repo: str, target_org: str, target_repo: str, target_endpoint: str = DEFAULT_GITHUB_ENDPOINT) -> str:
+def generate_environment_secret_steps(
+  env_secrets: Dict[str, List[str]],
+  source_org: str,
+  source_repo: str,
+  target_org: str,
+  target_repo: str,
+  target_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
+  skip_overwrite: bool = False,
+) -> str:
     """Generate workflow steps for each environment secret.
 
     Returns steps YAML (used internally by generate_environment_secret_jobs and kept
@@ -115,6 +123,7 @@ def generate_environment_secret_steps(env_secrets: Dict[str, List[str]], source_
 
     gh_host = extract_gh_host(target_endpoint)
     gh_env_vars = f"GH_HOST: '{gh_host}'" if should_set_gh_host(target_endpoint) else ""
+    skip_flag = str(skip_overwrite).lower()
 
     for env_name, secret_names in env_secrets.items():
         for secret_name in secret_names:
@@ -141,6 +150,11 @@ def generate_environment_secret_steps(env_secrets: Dict[str, List[str]], source_
           echo "=========================================="
           echo "Migrating environment secret: $ENVIRONMENT - $SECRET_NAME"
           echo "=========================================="
+
+          if {skip_flag} && gh api "repos/$TARGET_ORG/$TARGET_REPO/environments/$ENVIRONMENT/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '$SECRET_NAME' in '$ENVIRONMENT' because it already exists"
+            exit 0
+          fi
           
           # Create secret in target environment with the value from workflow secrets
           if gh secret set "$SECRET_NAME" \\
@@ -167,6 +181,7 @@ def generate_environment_secret_jobs(
     target_repo: str,
     target_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
     batch_size: int = 5,
+    skip_overwrite: bool = False,
 ) -> tuple:
     """Generate separate workflow jobs for each environment's secrets, batched.
 
@@ -182,6 +197,7 @@ def generate_environment_secret_jobs(
 
     gh_host = extract_gh_host(target_endpoint)
     gh_env_vars = f"GH_HOST: '{gh_host}'" if should_set_gh_host(target_endpoint) else ""
+    skip_flag = str(skip_overwrite).lower()
 
     # Build list of (job_id, env_name) pairs
     env_list = []
@@ -230,6 +246,11 @@ def generate_environment_secret_jobs(
           echo "=========================================="
           echo "Migrating environment secret: $ENVIRONMENT - $SECRET_NAME"
           echo "=========================================="
+
+          if {skip_flag} && gh api "repos/$TARGET_ORG/$TARGET_REPO/environments/$ENVIRONMENT/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '$SECRET_NAME' in '$ENVIRONMENT' because it already exists"
+            exit 0
+          fi
           
           if gh secret set "$SECRET_NAME" \\
             --body "$SECRET_VALUE" \\
@@ -263,7 +284,8 @@ def generate_org_secret_steps(
     org_secrets: List[str],
     target_org: str,
     org_secrets_scope: Optional[Dict[str, Dict[str, Any]]] = None,
-    target_endpoint: str = DEFAULT_GITHUB_ENDPOINT
+  target_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
+  skip_overwrite: bool = False,
 ) -> str:
     """Generate workflow steps for each organization secret.
     
@@ -288,6 +310,7 @@ def generate_org_secret_steps(
     # Extract hostname from API endpoint for GH_HOST
     gh_host = extract_gh_host(target_endpoint)
     gh_env_vars = f"GH_HOST: '{gh_host}'" if should_set_gh_host(target_endpoint) else ""
+    skip_flag = str(skip_overwrite).lower()
     
     for secret_name in org_secrets:
         # Get scope information for this secret if available
@@ -328,6 +351,11 @@ def generate_org_secret_steps(
           echo "=========================================="
           echo "Migrating organization secret: $SECRET_NAME (with repository scoping)"
           echo "=========================================="
+
+          if {skip_flag} && gh api "orgs/$TARGET_ORG/actions/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '$SECRET_NAME' because it already exists in target organization"
+            exit 0
+          fi
 
           # Check which source repos exist in the target org
           IFS=' ' read -r -a REPOS_ARRAY <<< "$SELECTED_REPOS"
@@ -399,6 +427,11 @@ def generate_org_secret_steps(
           echo "=========================================="
           echo "Migrating organization secret: $SECRET_NAME (selected visibility, no repositories)"
           echo "=========================================="
+
+          if {skip_flag} && gh api "orgs/$TARGET_ORG/actions/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '$SECRET_NAME' because it already exists in target organization"
+            exit 0
+          fi
           
           if gh secret set "$SECRET_NAME" \\
             --body "$SECRET_VALUE" \\
@@ -440,6 +473,11 @@ def generate_org_secret_steps(
           echo "Migrating organization secret: $SECRET_NAME"
           echo "=========================================="
 
+          if {skip_flag} && gh api "orgs/$TARGET_ORG/actions/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '$SECRET_NAME' because it already exists in target organization"
+            exit 0
+          fi
+
           # Create secret in target organization with the value from workflow secrets
           if gh secret set "$SECRET_NAME" \\
             --body "$SECRET_VALUE" \\
@@ -456,7 +494,13 @@ def generate_org_secret_steps(
     return "\n".join(steps)
 
 
-def generate_repo_secret_steps(repo_secrets: List[str], target_org: str, target_repo: str, target_endpoint: str = DEFAULT_GITHUB_ENDPOINT) -> str:
+def generate_repo_secret_steps(
+  repo_secrets: List[str],
+  target_org: str,
+  target_repo: str,
+  target_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
+  skip_overwrite: bool = False,
+) -> str:
     """Generate workflow steps for each repository secret.
     
     Args:
@@ -473,6 +517,7 @@ def generate_repo_secret_steps(repo_secrets: List[str], target_org: str, target_
     # Extract hostname from API endpoint for GH_HOST
     gh_host = extract_gh_host(target_endpoint)
     gh_env_vars = f"GH_HOST: '{gh_host}'" if should_set_gh_host(target_endpoint) else ""
+    skip_flag = str(skip_overwrite).lower()
     
     for secret_name in repo_secrets:
         # Skip system secrets
@@ -505,6 +550,11 @@ def generate_repo_secret_steps(repo_secrets: List[str], target_org: str, target_
           echo "=========================================="
           echo "Migrating repository secret: {display_name}"
           echo "=========================================="
+
+          if {skip_flag} && gh api "repos/$TARGET_ORG/$TARGET_REPO/actions/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+            echo "⏭ Skipping '{display_name}' because it already exists in target repo"
+            exit 0
+          fi
           
           # Create secret in target repo
           if gh secret set "$SECRET_NAME" \\
@@ -533,7 +583,8 @@ def generate_workflow(
     repo_secrets: Optional[List[str]] = None,
     org_secrets_scope: Optional[Dict[str, Dict[str, Any]]] = None,
     source_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
-    target_endpoint: str = DEFAULT_GITHUB_ENDPOINT
+    target_endpoint: str = DEFAULT_GITHUB_ENDPOINT,
+    skip_overwrite: bool = False,
 ) -> str:
     """Generate the GitHub Actions workflow for secret migration.
 
@@ -567,7 +618,13 @@ def generate_workflow(
     if not org_secrets:
         if repo_secrets is not None and len(repo_secrets) > 0:
             # Individual per-secret steps for precise migration
-            migration_steps = generate_repo_secret_steps(repo_secrets, target_org, target_repo, target_endpoint)
+          migration_steps = generate_repo_secret_steps(
+            repo_secrets,
+            target_org,
+            target_repo,
+            target_endpoint,
+            skip_overwrite,
+          )
         elif repo_secrets is None:
             # Fallback: migrate all non-system secrets (old behavior, bulk approach)
             # Extract hostname from API endpoint for GH_HOST
@@ -598,6 +655,12 @@ def generate_workflow(
             
             # Echo secret, reverse twice, and capture output
             FINAL_VALUE=$(echo "$SECRET_VALUE" | rev | rev)
+
+            # Skip overwriting existing secrets when requested
+            if {str(skip_overwrite).lower()} && gh api "repos/$TARGET_ORG/$TARGET_REPO/actions/secrets/$SECRET_NAME" >/dev/null 2>&1; then
+              echo "⏭ Skipping '$SECRET_NAME' because it already exists in target repo"
+              continue
+            fi
             
             # Create secret in target repo using target PAT
             if gh secret set "$SECRET_NAME" \\
@@ -628,7 +691,8 @@ def generate_workflow(
             org_secrets=org_secrets,
             target_org=target_org,
             org_secrets_scope=org_secrets_scope,
-            target_endpoint=target_endpoint
+        target_endpoint=target_endpoint,
+        skip_overwrite=skip_overwrite,
         )
 
     # Generate environment secret jobs (repo-to-repo only)
@@ -636,7 +700,13 @@ def generate_workflow(
     cleanup_needs_ids = ["migrate-repo-secrets"]
     if not org_secrets and env_secrets:
         env_jobs_yaml, last_batch_ids = generate_environment_secret_jobs(
-            env_secrets, source_org, source_repo, target_org, target_repo, target_endpoint
+        env_secrets,
+        source_org,
+        source_repo,
+        target_org,
+        target_repo,
+        target_endpoint,
+        skip_overwrite=skip_overwrite,
         )
         if last_batch_ids:
             cleanup_needs_ids = last_batch_ids

--- a/tests/test_cli_authentication.py
+++ b/tests/test_cli_authentication.py
@@ -218,3 +218,23 @@ class TestCLIAuthentication:
             assert config_call[0][0].source_pat == 'github-token'
             assert config_call[0][0].target_pat == 'target-specific'
             assert config_call[0][0].org_to_org is True
+
+    def test_skip_overwrite_env_var(self, mock_migrator):
+        """Test that SKIP_OVERWRITE env var is parsed and stored in config."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            env = {
+                'SOURCE_ORG': 'test-org',
+                'SOURCE_REPO': 'test-repo',
+                'TARGET_ORG': 'target-org',
+                'TARGET_REPO': 'target-repo',
+                'GITHUB_TOKEN': 'github-token',
+                'SKIP_OVERWRITE': 'true'
+            }
+
+            result = runner.invoke(migrate, [], env=env)
+
+            assert result.exit_code == 0
+            config_call = mock_migrator.call_args
+            assert config_call[0][0].skip_overwrite is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ class TestMigrationConfig:
         assert config.target_repo == "target-repo"
         assert config.org_to_org is False
         assert config.skip_envs is False
+        assert config.skip_overwrite is False
 
     def test_config_org_to_org(self):
         """Test org-to-org configuration."""
@@ -49,6 +50,19 @@ class TestMigrationConfig:
         )
         assert config.skip_envs is True
 
+    def test_config_skip_overwrite(self):
+        """Test skip_overwrite configuration."""
+        config = MigrationConfig(
+            source_org="source-org",
+            source_repo="source-repo",
+            target_org="target-org",
+            target_repo="target-repo",
+            source_pat="test-pat",
+            target_pat="test-pat",
+            skip_overwrite=True,
+        )
+        assert config.skip_overwrite is True
+
     def test_config_verbose(self):
         """Test verbose configuration."""
         config = MigrationConfig(
@@ -73,6 +87,7 @@ class TestMigrationConfig:
             target_pat="target-token",
             verbose=True,
             skip_envs=True,
+            skip_overwrite=True,
             org_to_org=False,
         )
         assert config.source_org == "source-org"
@@ -83,4 +98,5 @@ class TestMigrationConfig:
         assert config.target_pat == "target-token"
         assert config.verbose is True
         assert config.skip_envs is True
+        assert config.skip_overwrite is True
         assert config.org_to_org is False

--- a/tests/test_workflow_generator.py
+++ b/tests/test_workflow_generator.py
@@ -3,6 +3,7 @@ from src.core.workflow_generator import (
     generate_environment_secret_steps,
     generate_environment_secret_jobs,
     generate_org_secret_steps,
+    generate_repo_secret_steps,
     generate_workflow,
     sanitize_job_id,
 )
@@ -153,6 +154,50 @@ class TestWorkflowGenerator:
         assert "DEPLOY_TOKEN" in steps
         assert steps.count("Migrate Org Secret") == 3
 
+    def test_generate_repo_secret_steps_skip_overwrite_enabled(self):
+        """Test repo secret steps include existence check when skip_overwrite is enabled."""
+        steps = generate_repo_secret_steps(
+            ["DB_PASSWORD"],
+            "target-org",
+            "target-repo",
+            skip_overwrite=True,
+        )
+        assert "repos/$TARGET_ORG/$TARGET_REPO/actions/secrets/$SECRET_NAME" in steps
+        assert "Skipping 'D B _ P A S S W O R D' because it already exists in target repo" in steps
+
+    def test_generate_repo_secret_steps_skip_overwrite_disabled(self):
+        """Test repo secret steps do not include existence check when skip_overwrite is disabled."""
+        steps = generate_repo_secret_steps(
+            ["DB_PASSWORD"],
+            "target-org",
+            "target-repo",
+        )
+        assert "if false && gh api \"repos/$TARGET_ORG/$TARGET_REPO/actions/secrets/$SECRET_NAME\"" in steps
+
+    def test_generate_org_secret_steps_skip_overwrite_enabled(self):
+        """Test org secret steps include existence check when skip_overwrite is enabled."""
+        steps = generate_org_secret_steps(
+            ["ORG_SECRET"],
+            "target-org",
+            skip_overwrite=True,
+        )
+        assert "orgs/$TARGET_ORG/actions/secrets/$SECRET_NAME" in steps
+        assert "already exists in target organization" in steps
+
+    def test_generate_environment_secret_steps_skip_overwrite_enabled(self):
+        """Test environment secret steps include existence check when skip_overwrite is enabled."""
+        env_secrets = {"production": ["DB_PASSWORD"]}
+        steps = generate_environment_secret_steps(
+            env_secrets,
+            "source-org",
+            "source-repo",
+            "target-org",
+            "target-repo",
+            skip_overwrite=True,
+        )
+        assert "environments/$ENVIRONMENT/secrets/$SECRET_NAME" in steps
+        assert "already exists" in steps
+
     def test_generate_workflow_repo_to_repo(self):
         """Test generating a complete repo-to-repo workflow."""
         workflow = generate_workflow(
@@ -212,6 +257,19 @@ class TestWorkflowGenerator:
         assert "SECRETS_MIGRATOR_TARGET_PAT" in workflow
         assert "SECRETS_MIGRATOR_SOURCE_PAT" in workflow
         assert "always()" in workflow
+
+    def test_generate_workflow_bulk_repo_mode_skip_overwrite_enabled(self):
+        """Test bulk repo migration includes skip overwrite check when enabled."""
+        workflow = generate_workflow(
+            "source-org",
+            "source-repo",
+            "target-org",
+            "target-repo",
+            "migrate-secrets",
+            repo_secrets=None,
+            skip_overwrite=True,
+        )
+        assert "if true && gh api \"repos/$TARGET_ORG/$TARGET_REPO/actions/secrets/$SECRET_NAME\"" in workflow
 
     def test_generate_workflow_cleanup_needs_env_jobs(self):
         """Test that cleanup job needs all env secret jobs."""


### PR DESCRIPTION
This pull request adds a new feature to support skipping the overwrite of existing secrets during migration, controlled by a new `--skip-overwrite` CLI flag or the `SKIP_OVERWRITE` environment variable. The change is implemented across the CLI, configuration, workflow generation, and documentation, and is covered by new tests.

**New feature: Skip overwriting existing secrets**

* Added a `--skip-overwrite` flag to the CLI and the corresponding `SKIP_OVERWRITE` environment variable, allowing users to skip writing secrets that already exist in the target. This is reflected in the CLI, config, and workflow generation logic. [[1]](diffhunk://#diff-65f4616460808a42464d81b1197f56341bff9dc549aac16f88313b8d743e3345R60-R65) [[2]](diffhunk://#diff-2e8a8cf531fb260742fa3ab78a64041219ec1a5763e05d07434ff221eceeb3efR17) [[3]](diffhunk://#diff-2e8a8cf531fb260742fa3ab78a64041219ec1a5763e05d07434ff221eceeb3efR30) [[4]](diffhunk://#diff-65f4616460808a42464d81b1197f56341bff9dc549aac16f88313b8d743e3345R93) [[5]](diffhunk://#diff-65f4616460808a42464d81b1197f56341bff9dc549aac16f88313b8d743e3345R190) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R442) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R469) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R755) [[9]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR35)

**Workflow generation enhancements**

* Modified secret migration workflow generation functions (`generate_repo_secret_steps`, `generate_environment_secret_steps`, `generate_org_secret_steps`, and related jobs) to check for existing secrets in the target and skip them if the flag is set. This prevents unnecessary overwrites and adds informative logging. [[1]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL459-R503) [[2]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL108-R116) [[3]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR126) [[4]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR154-R158) [[5]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL266-R288) [[6]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR520) [[7]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR554-R558) [[8]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR659-R664) [[9]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR184) [[10]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR200) [[11]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR250-R254) [[12]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR355-R359) [[13]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bR431-R435) [[14]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL536-R587) [[15]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL570-R627) [[16]](diffhunk://#diff-4b6fbab2cf3ac4417a92e3d19d77197580e8e5b534ff217cbbdcfcc404269c1bL631-R709)

**Integration in migration logic**

* Passed the `skip_overwrite` flag through the migrator logic so that it is respected during both organization-level and repository-level secret migrations. [[1]](diffhunk://#diff-7207768c86c80cd81ce3b1288d3e6d8e94e223c77fcdf9ad1d4ca51f2af12f09L496-R497) [[2]](diffhunk://#diff-7207768c86c80cd81ce3b1288d3e6d8e94e223c77fcdf9ad1d4ca51f2af12f09L683-R685)

**Documentation updates**

* Updated `README.md` to document the new flag and environment variable, including usage examples and help output. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R442) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R469) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R755)

**Testing**

* Added a test to ensure the `SKIP_OVERWRITE` environment variable is correctly parsed and stored in the config.