### PR TITLE
fix: skip environments with no secrets when generating migration workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,10 +195,10 @@ jobs:
               INSERT_LINE=$(wc -l < CHANGELOG.md)
             fi
           else
-            # No [Unreleased] section; insert at the first section heading, or end of file if none
+            # No [Unreleased] section; insert before the first version heading, or end of file if none
             FIRST_SECTION_LINE=$(grep -n "^## " CHANGELOG.md | head -1 | cut -d: -f1 || true)
             if [ -n "$FIRST_SECTION_LINE" ]; then
-              INSERT_LINE=$FIRST_SECTION_LINE
+              INSERT_LINE=$((FIRST_SECTION_LINE - 1))
             else
               INSERT_LINE=$(wc -l < CHANGELOG.md)
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 This changelog is auto-generated from [Conventional Commits](https://www.conventionalcommits.org/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-01-21
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/src/core/migrator.py
+++ b/src/core/migrator.py
@@ -616,7 +616,7 @@ class Migrator:
                     secret_list = ", ".join(secret_names)
                     self.log.info(f"  - {env_name}: {secret_list}")
                 else:
-                    self.log.info(f"  - {env_name}: (no secrets)")
+                    self.log.info(f"  - {env_name}: (no secrets, skipping from workflow)")
         else:
             self.log.debug("No environment secrets found in source repository")
 

--- a/src/core/workflow_generator.py
+++ b/src/core/workflow_generator.py
@@ -199,11 +199,16 @@ def generate_environment_secret_jobs(
     gh_env_vars = f"GH_HOST: '{gh_host}'" if should_set_gh_host(target_endpoint) else ""
     skip_flag = str(skip_overwrite).lower()
 
-    # Build list of (job_id, env_name) pairs
+    # Build list of (job_id, env_name) pairs — skip envs with no secrets
     env_list = []
     for env_name in env_secrets:
+        if not env_secrets[env_name]:
+            continue
         job_id = f"migrate-env-{sanitize_job_id(env_name)}"
         env_list.append((job_id, env_name))
+
+    if not env_list:
+        return ("", [])
 
     # Split into batches
     batches = []

--- a/tests/test_workflow_generator.py
+++ b/tests/test_workflow_generator.py
@@ -100,6 +100,25 @@ class TestWorkflowGenerator:
         assert jobs_yaml == ""
         assert last_ids == []
 
+    def test_generate_environment_secret_jobs_envs_with_no_secrets(self):
+        """Test that environments with empty secret lists produce no jobs."""
+        env_secrets = {"production": [], "staging": []}
+        jobs_yaml, last_ids = generate_environment_secret_jobs(
+            env_secrets, "source-org", "source-repo", "target-org", "target-repo"
+        )
+        assert jobs_yaml == ""
+        assert last_ids == []
+
+    def test_generate_environment_secret_jobs_mixed_empty_and_populated(self):
+        """Test that only environments with secrets get jobs."""
+        env_secrets = {"production": ["DB_PASSWORD"], "staging": []}
+        jobs_yaml, last_ids = generate_environment_secret_jobs(
+            env_secrets, "source-org", "source-repo", "target-org", "target-repo"
+        )
+        assert "environment: production" in jobs_yaml
+        assert "staging" not in jobs_yaml
+        assert last_ids == ["migrate-env-production"]
+
     def test_generate_environment_secret_jobs_batched(self):
         """Test that >5 environments are batched into groups of 5."""
         env_secrets = {f"env-{i}": [f"SECRET_{i}"] for i in range(7)}


### PR DESCRIPTION
Environments without secrets were producing invalid GitHub Actions YAML
with empty `steps:` blocks. Now `generate_environment_secret_jobs()`
filters out environments that have no secrets before generating jobs,
preventing invalid workflow output.
