### PR TITLE
fix: allow migration when only environment secrets exist

### DIFF
--- a/src/core/migrator.py
+++ b/src/core/migrator.py
@@ -593,15 +593,14 @@ class Migrator:
             if name not in ("github_token", "SECRETS_MIGRATOR_PAT", "SECRETS_MIGRATOR_TARGET_PAT", "SECRETS_MIGRATOR_SOURCE_PAT")
         ]
 
-        if not secrets_to_migrate:
-            self.log.info("No secrets to migrate (found only system secrets)")
-            return
+        if secrets_to_migrate:
+            self.log.info(f"Secrets to migrate ({len(secrets_to_migrate)} total):")
+            for name in secrets_to_migrate:
+                self.log.info(f"  - {name}")
+        else:
+            self.log.info("No repository secrets to migrate (found only system secrets)")
 
-        self.log.info(f"Secrets to migrate ({len(secrets_to_migrate)} total):")
-        for name in secrets_to_migrate:
-            self.log.info(f"  - {name}")
-
-        # Step 2b: List environment secrets from source repository (for informational purposes)
+        # Step 2b: List environment secrets from source repository
         self.log.debug("Fetching environment secrets from source repository...")
         env_secrets_info = self.source_api.list_all_environments_with_secrets(
             self.config.source_org, self.config.source_repo
@@ -619,6 +618,12 @@ class Migrator:
                     self.log.info(f"  - {env_name}: (no secrets, skipping from workflow)")
         else:
             self.log.debug("No environment secrets found in source repository")
+
+        # Check if there's anything to migrate at all
+        has_env_secrets = any(env_secrets_info.get(env) for env in env_secrets_info) if env_secrets_info else False
+        if not secrets_to_migrate and not has_env_secrets:
+            self.log.info("No secrets to migrate (no repo secrets or environment secrets found)")
+            return
 
         # Step 3: Get default branch and commit SHA
         self.log.debug("Getting default branch...")

--- a/tests/test_environment_secret_migration.py
+++ b/tests/test_environment_secret_migration.py
@@ -556,7 +556,7 @@ class TestMigratorEnvironmentSecretsInRun:
         info_calls = [str(c) for c in mock_logger.info.call_args_list]
         assert any("Environment secrets to migrate" in c for c in info_calls)
         assert any("production" in c and "DB_PASSWORD" in c for c in info_calls)
-        assert any("staging" in c and "(no secrets)" in c for c in info_calls)
+        assert any("staging" in c and "(no secrets, skipping from workflow)" in c for c in info_calls)
 
     @patch('src.core.migrator.generate_workflow')
     @patch('src.clients.github.Github')
@@ -564,7 +564,7 @@ class TestMigratorEnvironmentSecretsInRun:
         self, mock_github_class, mock_generate_workflow,
         migration_config, mock_logger
     ):
-        """Test that run() returns early if only system secrets exist (no workflow generated)."""
+        """Test that run() returns early if only system secrets and no env secrets exist."""
         mock_github_class.return_value = Mock()
         migrator = Migrator(migration_config, mock_logger)
 
@@ -580,6 +580,8 @@ class TestMigratorEnvironmentSecretsInRun:
         migrator.source_api.list_repo_secrets.return_value = [
             "github_token", "SECRETS_MIGRATOR_PAT"
         ]
+        # No environment secrets either
+        migrator.source_api.list_all_environments_with_secrets.return_value = {}
         migrator.source_api.get_rate_limit_info.return_value = {
             'remaining': 5000, 'limit': 5000, 'reset_time': 0, 'reset_in_seconds': 0
         }
@@ -588,6 +590,49 @@ class TestMigratorEnvironmentSecretsInRun:
 
         # generate_workflow should never be called
         mock_generate_workflow.assert_not_called()
-        # list_all_environments_with_secrets should not be called either
-        # (it comes after the early return)
-        migrator.source_api.list_all_environments_with_secrets.assert_not_called()
+
+    @patch('src.core.migrator.generate_workflow')
+    @patch('src.clients.github.Github')
+    def test_run_proceeds_with_only_env_secrets(
+        self, mock_github_class, mock_generate_workflow,
+        migration_config, mock_logger
+    ):
+        """Test that run() proceeds when there are no repo secrets but env secrets exist."""
+        mock_github_class.return_value = Mock()
+        migrator = Migrator(migration_config, mock_logger)
+
+        migrator.source_api = Mock(spec=GitHubClient)
+        migrator.target_api = Mock(spec=GitHubClient)
+
+        migrator._validate_permissions = Mock()
+        migrator._wait_for_rate_limit_reset = Mock()
+        migrator._recreate_environments = Mock()
+        migrator._check_rate_limits = Mock()
+
+        # No repo secrets (only system ones)
+        migrator.source_api.list_repo_secrets.return_value = [
+            "github_token", "SECRETS_MIGRATOR_PAT"
+        ]
+        # But environment secrets exist
+        migrator.source_api.list_all_environments_with_secrets.return_value = {
+            "production": ["DB_PASSWORD", "API_KEY"]
+        }
+        migrator.source_api.get_rate_limit_info.return_value = {
+            'remaining': 5000, 'limit': 5000, 'reset_time': 0, 'reset_in_seconds': 0
+        }
+        migrator.source_api.get_default_branch.return_value = "main"
+        migrator.source_api.get_commit_sha.return_value = "abc123"
+        migrator.source_api.delete_branch.return_value = None
+        migrator.source_api.create_repo_secret.return_value = None
+        migrator.source_api.create_branch.return_value = None
+        migrator.source_api.create_file.return_value = "sha456"
+        migrator._get_workflow_run_url = Mock(return_value="")
+        mock_generate_workflow.return_value = "workflow content"
+
+        migrator.run()
+
+        # generate_workflow SHOULD be called since env secrets exist
+        mock_generate_workflow.assert_called_once()
+        call_kwargs = mock_generate_workflow.call_args
+        # env_secrets should include the production environment
+        assert "production" in (call_kwargs.kwargs.get('env_secrets') or call_kwargs[1].get('env_secrets', {}))


### PR DESCRIPTION
Previously, the migrator returned early when no repo-level secrets were
found, skipping environment secret discovery entirely. Now it checks both
repo and environment secrets before deciding there's nothing to migrate,
enabling workflows to be generated for repos that only have env secrets.
